### PR TITLE
BUG: Handle 414 urllen error

### DIFF
--- a/osmpy/__init__.py
+++ b/osmpy/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-from osmpy.core import get, list_queries
+from .core import get, list_queries

--- a/osmpy/core.py
+++ b/osmpy/core.py
@@ -12,8 +12,9 @@ from retry import retry
 import pandas as pd
 import warnings
 import re
-import osmpy.queries as qs
+from .queries import *
 import sys
+import inspect
 
 warnings.filterwarnings("ignore", category=FutureWarning)
 
@@ -34,8 +35,10 @@ def get_area(s):
     proj = partial(
         pyproj.transform, pyproj.Proj(init="epsg:4326"), pyproj.Proj(init="epsg:3857")
     )
-
-    return transform(proj, s).area / 1e6  # km
+    area = transform(proj, s).area / 1e6  # km
+    if pd.isnull(area):
+        raise ValueError("The coordinates format is incorect. The expected format: lng lat, lng lat, lng lat, ...")
+    return area
 
 
 def threshold_func(g, value):
@@ -43,7 +46,7 @@ def threshold_func(g, value):
     return get_area(g) < value
 
 
-def katana(geometry, threshold_func, threshold_value, count=0):
+def katana(geometry, threshold_func, threshold_value, count=0, urllen_threshold=7648):
     """Split a Polygon into two parts across it's shortest dimension
     
     KUDOS https://snorfalorpagus.net/blog/2016/03/13/splitting-large-polygons-for-faster-intersections/
@@ -51,9 +54,10 @@ def katana(geometry, threshold_func, threshold_value, count=0):
     bounds = geometry.bounds
     width = bounds[2] - bounds[0]
     height = bounds[3] - bounds[1]
-    if threshold_func(geometry, threshold_value) or count == 250:
-        # either the polygon is smaller than the threshold, or the maximum
-        # number of recursions has been reached
+    if (threshold_func(geometry, threshold_value) and (len(to_overpass_coords(geometry)) < urllen_threshold)) or (count == 250):
+        # either the polygon is smaller than the threshold
+        # AND the length of the expected url is short enough to avoid Error 414
+        # OR the maximum number of recursions has been reached
         return [geometry]
     if height >= width:
         # split left to right
@@ -73,7 +77,7 @@ def katana(geometry, threshold_func, threshold_value, count=0):
             c = [c]
         for e in c:
             if isinstance(e, (Polygon, MultiPolygon)):
-                result.extend(katana(e, threshold_func, threshold_value, count + 1))
+                result.extend(katana(e, threshold_func, threshold_value, count + 1, urllen_threshold=urllen_threshold))
     if count > 0:
         return result
     # convert multipart into singlepart
@@ -125,7 +129,7 @@ def overpass_request(query, boundary):
     return pd.DataFrame(response['elements'])
 
 
-def get(query, boundary, threshold_value=1000000):
+def get(query, boundary, threshold_value=1000000, urllen_threshold=7648):
     """Get Open Street Maps highways length in meters and object count for a given boundary
 
     It splits the regions to manage overpass turbo limits.
@@ -138,6 +142,8 @@ def get(query, boundary, threshold_value=1000000):
         A shapely polygon
     threshold_value : int, optional
         Maximum area in sq km to split the polygons, by default 1000000
+    urllen_threshold : int, optional
+        Maximum length of the url to send to Overpass API, by default 7648 (found experimentally)
 
     Returns
     -------
@@ -149,12 +155,24 @@ def get(query, boundary, threshold_value=1000000):
         if query in _get_queries_names():
             query_obj = getattr(sys.modules['osmpy.queries'], query)()
         else:
-            query_obj = qs.QueryType()
+            query_obj = QueryType()
             query_obj.query = query
     elif isinstance(query, type):
         query_obj = query()
 
-    boundaries = katana(boundary, threshold_func, threshold_value)
+    boundaries = katana(boundary, threshold_func, threshold_value, urllen_threshold=urllen_threshold)
+    
+    # Looking for the boundaries which generate too long URLs resulting in Error 414.
+    # If found the boundaries will be processed again by `katana()`
+    while True:
+        for geo in boundaries:
+            urllen = len(to_overpass_coords(geo))
+            if urllen >= urllen_threshold:
+                boundaries.remove(geo)
+                boundaries.extend(katana(geo, threshold_func, threshold_value, urllen_threshold=urllen_threshold))
+                break
+        else:
+            break
 
     responses = []
     for bound in boundaries:
@@ -169,8 +187,8 @@ def get(query, boundary, threshold_value=1000000):
     return data
 
 def _get_queries_names():
-
-    return [t for t in dir(qs) if (t[0].isupper() and (t is not 'QueryType'))]
+    query_classes = [c[0] for c in inspect.getmembers(sys.modules[__name__], inspect.isclass) if QueryType in c[1].__bases__]
+    return query_classes
 
 def list_queries():
     

--- a/osmpy/core.py
+++ b/osmpy/core.py
@@ -31,13 +31,13 @@ def check_length(s, threshold=3000):
     return len(str(s)) < threshold
 
 def get_area(s):
+    """Get the area of a shapely polygon in sq km"""
     s = shape(s)
     proj = partial(
         pyproj.transform, pyproj.Proj(init="epsg:4326"), pyproj.Proj(init="epsg:3857")
     )
     area = transform(proj, s).area / 1e6  # km
-    if pd.isnull(area):
-        raise ValueError("The coordinates format is incorect. The expected format: lng lat, lng lat, lng lat, ...")
+    
     return area
 
 
@@ -130,7 +130,7 @@ def overpass_request(query, boundary):
 
 
 def get(query, boundary, threshold_value=1000000, urllen_threshold=7648):
-    """Get Open Street Maps highways length in meters and object count for a given boundary
+    """Get Open Street Maps Turbo Query for a given boundary
 
     It splits the regions to manage overpass turbo limits.
 
@@ -197,3 +197,5 @@ def list_queries():
         'docstring': re.sub('\s+',' ',
                 getattr(sys.modules['osmpy.queries'], t)().docstring)}
      for t in _get_queries_names()])
+
+

--- a/osmpy/queries.py
+++ b/osmpy/queries.py
@@ -19,7 +19,7 @@ class POIs(QueryType):
     Points of Interest being all shops and amenities.
     """
     
-    def prep_pois(x):
+    def prep_pois(self, x):
     
         if x.get('amenity'):
             return f'amenity:{x["amenity"]}'
@@ -31,7 +31,7 @@ class POIs(QueryType):
     def postprocess(self, df):
         """Post process API result
         """
-        df['poi'] = df['tags'].apply(prep_pois)
+        df['poi'] = df['tags'].apply(self.prep_pois)
         
         return df
 

--- a/osmpy/queries.py
+++ b/osmpy/queries.py
@@ -5,7 +5,7 @@ class QueryType:
     def postprocess(self, df):
         return df
 
-class POIs(osmpy.queries.QueryType):
+class POIs(QueryType):
 
     query = """
         [out:json];
@@ -87,4 +87,13 @@ class RoadLength(QueryType):
     """
 
     def postprocess(self, df):
-        return df['tags'].apply(pd.Series).groupby('highway').sum()
+        if 'tags' in df.columns:
+            return df['tags'].apply(pd.Series).astype({ # It seems API may generate dataframe with strings
+                'highway': 'str',
+                'count': 'int',
+                'length': 'float'
+            }).groupby('highway').sum()
+        else:
+            empty = pd.DataFrame(columns=['count', 'length']).astype({'count': 'int', 'length': 'float'})
+            empty.index.name = 'highway'
+            return empty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "AM-331-A3 Licencia de Software"
 name = "osmpy"
 readme = "README.md"
 repository = "https://github.com/JoaoCarabetta/osmpy"
-version = "0.1.1"
+version = "0.1.2"
 
 [tool.poetry.dependencies]
 python = "^3.6"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,48 @@
+import pytest
+from shapely.geometry import Polygon
+from osmpy.core import simplify, check_length, get_area, threshold_func, katana, to_geojson, swipe, flatten, to_overpass_coords, _get_queries_names
+
+def test_simplify():
+    polygon = Polygon([(-70, 40), (-70, 41), (-69, 41), (-69, 40), (-70, 40)])  # roughly 111 x 111 km square
+    simplified = simplify(polygon)
+    assert isinstance(simplified, Polygon)
+
+def test_check_length():
+    polygon = Polygon([(-70, 40), (-70, 41), (-69, 41), (-69, 40), (-70, 40)])
+    assert check_length(polygon) is True
+
+def test_get_area():
+    polygon = Polygon([(-70, 40), (-70, 41), (-69, 41), (-69, 40), (-70, 40)])
+    area = get_area(polygon)
+    assert 11000 <= area <= 16298  # considering a roughly 111 x 111 km square
+
+def test_threshold_func():
+    polygon = Polygon([(-70, 40), (-70, 41), (-69, 41), (-69, 40), (-70, 40)])
+    assert threshold_func(polygon, 16298) is True  # considering a roughly 111 x 111 km square
+
+def test_katana():
+    polygon = Polygon([(-70, 40), (-70, 41), (-69, 41), (-69, 40), (-70, 40)])
+    result = katana(polygon, threshold_func, 15000)
+    assert isinstance(result, list)
+    assert all(isinstance(r, Polygon) for r in result)
+
+def test_to_geojson():
+    polygon = Polygon([(-70, 40), (-70, 41), (-69, 41), (-69, 40), (-70, 40)])
+    result = to_geojson(polygon)
+    assert isinstance(result, list)
+    assert len(result) == 5  # 5 points in a Square, last one equals to the first
+
+def test_swipe():
+    coords = [(-70, 40), (-70, 41), (-69, 41), (-70, 40)]
+    result = swipe(coords)
+    assert result == [[40, -70], [41, -70], [41, -69], [40, -70]]
+
+def test_flatten():
+    coords = [[-70, 40], [-70, 41], [-69, 41], [-69, 40]]
+    result = flatten(coords)
+    assert result == ['-70', '40', '-70', '41', '-69', '41', '-69', '40']
+
+def test_to_overpass_coords():
+    polygon = Polygon([(-70, 40), (-70, 41), (-69, 41), (-69, 40), (-70, 40)])
+    result = to_overpass_coords(polygon)
+    assert isinstance(result, str)


### PR DESCRIPTION
1. Added a ValueError when get_area returns a null value (likely due to improper formatting).
2. Adjusted the RoadLength class to properly handle cases where it receives string data from the OverPass API instead of numeric data.
3. The katana() and get() functions have been updated to properly handle complex boundary structures and avoid Error 414.
4. The RoadLength query will now return an empty DataFrame if there are no roads within the given boundaries (previously raised an error).
5. Made some cosmetic changes.